### PR TITLE
Wrapping prepare command to ensure requirements are declared

### DIFF
--- a/src/main/java/frc/robot/subsystems/coraller/Coraller.java
+++ b/src/main/java/frc/robot/subsystems/coraller/Coraller.java
@@ -27,7 +27,10 @@ public class Coraller extends SubsystemBase {
     return startEnd(() -> Commands.parallel(
       elevator.setHeightCommand(cfg.elevatorPosition),
       angler.setAngleCommand(cfg.anglerPosition)
-    ), this::stopCommand)
+    ), () -> Commands.parallel(
+      elevator.stopCommand(),
+      angler.stopCommand()
+    ))
     .withName("PrepareToScoreReef");
   }
 

--- a/src/main/java/frc/robot/subsystems/coraller/Coraller.java
+++ b/src/main/java/frc/robot/subsystems/coraller/Coraller.java
@@ -24,10 +24,11 @@ public class Coraller extends SubsystemBase {
   }
 
   public Command prepareToScoreReef(ReefScoringConfiguration cfg) {
-    return runOnce(() -> Commands.parallel(
+    return runEnd(() -> Commands.parallel(
       elevator.setHeightCommand(cfg.elevatorPosition),
       angler.setAngleCommand(cfg.anglerPosition)
-    )).withName("PrepareToScoreReef");
+    ), this::stopCommand)
+    .withName("PrepareToScoreReef");
   }
 
   public Command intakeCoral() {

--- a/src/main/java/frc/robot/subsystems/coraller/Coraller.java
+++ b/src/main/java/frc/robot/subsystems/coraller/Coraller.java
@@ -24,10 +24,10 @@ public class Coraller extends SubsystemBase {
   }
 
   public Command prepareToScoreReef(ReefScoringConfiguration cfg) {
-    return Commands.parallel(
+    return runOnce(() -> Commands.parallel(
       elevator.setHeightCommand(cfg.elevatorPosition),
       angler.setAngleCommand(cfg.anglerPosition)
-    ).withName("PrepareToScoreReef");
+    )).withName("PrepareToScoreReef");
   }
 
   public Command intakeCoral() {

--- a/src/main/java/frc/robot/subsystems/coraller/Coraller.java
+++ b/src/main/java/frc/robot/subsystems/coraller/Coraller.java
@@ -24,7 +24,7 @@ public class Coraller extends SubsystemBase {
   }
 
   public Command prepareToScoreReef(ReefScoringConfiguration cfg) {
-    return runEnd(() -> Commands.parallel(
+    return startEnd(() -> Commands.parallel(
       elevator.setHeightCommand(cfg.elevatorPosition),
       angler.setAngleCommand(cfg.anglerPosition)
     ), this::stopCommand)


### PR DESCRIPTION
Since we are only interacting with subsystems, we never declare the requirement for the Coraller system. This ensures the Coraller subsystem is also included.