### PR TITLE
Fix up command requirements

### DIFF
--- a/src/main/java/frc/robot/subsystems/Climber.java
+++ b/src/main/java/frc/robot/subsystems/Climber.java
@@ -86,10 +86,6 @@ public class Climber extends SubsystemBase {
     private AnchorPosition(double percent) {
       this.percent = percent;
     }
-
-    public double getPercent() {
-      return percent;
-    }
   }
   
   public enum ReelState {
@@ -115,7 +111,7 @@ public class Climber extends SubsystemBase {
     builder.setSafeState(this::reelStop);
     builder.setActuator(true);
     builder.addBooleanProperty("IsAnchorEngaged", this::isEngaged, null);
-    builder.addDoubleProperty("AnchorPosition", () -> getAnchorPosition().getPercent(), null);
+    builder.addDoubleProperty("AnchorPosition", () -> getAnchorPosition().percent, null);
     builder.addStringProperty("ReelingStatus", reelState::toString, null);
   }
 }

--- a/src/main/java/frc/robot/subsystems/Elevator.java
+++ b/src/main/java/frc/robot/subsystems/Elevator.java
@@ -73,14 +73,13 @@ public class Elevator extends SubsystemBase {
   }
 
   public Command stopCommand() {
-    return runOnce(this::stop)
-      .withName("StopElevator");
+    var cmd = runOnce(this::stop);
+    return cmd.withName("StopElevator");
   }
 
   public Command setHeightCommand(double heightFromGround) {
-    return this.run(() -> setSetpointHeight(heightFromGround))
-      .until(this::isAtSetpoint)
-      .withName("SetElevatorSetpoint");
+    var cmd = this.run(() -> setSetpointHeight(heightFromGround)).until(this::isAtSetpoint);
+    return cmd.withName("SetElevatorSetpoint");
   }
 
   /**

--- a/src/main/java/frc/robot/subsystems/Flicker.java
+++ b/src/main/java/frc/robot/subsystems/Flicker.java
@@ -18,13 +18,10 @@ import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
+
 import frc.robot.Constants.FlickerConfig;
 import frc.robot.RobotContainer;
 import frc.robot.RobotMap;
-import frc.robot.subsystems.Elevator;
-import frc.robot.subsystems.coraller.Coraller.ReefScoringConfiguration;
-import frc.robot.Constants.CorallerConfig;
-import frc.robot.Constants.ElevatorConfig;
 
 public class Flicker extends SubsystemBase {
   private final SparkMax motor;
@@ -65,16 +62,13 @@ public class Flicker extends SubsystemBase {
   }
 
   public Command prepareToFlickCommand(ReefScoringConfiguration cfg) {
-    return Commands.parallel(
-      elevator.setHeightCommand(cfg.elevatorPosition),
-      setAngleCommand(cfg.flickerPosition)
-    ).withName("PrepareToFlick");
+    var cmd = Commands.parallel(elevator.setHeightCommand(cfg.elevatorPosition), setAngleCommand(cfg.flickerPosition));
+    return cmd.withName("PrepareToFlick");
   }
 
   public Command setAngleCommand(double angleDegrees) {
-    return this.run(() -> setSetpointAngle(angleDegrees))
-        .until(this::isAtSetpoint)
-        .withName("SetAnglerSetpoint");
+    var cmd = this.run(() -> setSetpointAngle(angleDegrees)).until(this::isAtSetpoint);
+    return cmd.withName("SetAnglerSetpoint");
   }
 
   public void setSetpointAngle(double setpointDegrees) {
@@ -108,8 +102,8 @@ public class Flicker extends SubsystemBase {
   }
 
   public Command stopCommand() {
-    return runOnce(this::stop)
-        .withName("StopFlicker");
+    var cmd = runOnce(this::stop);
+    return cmd.withName("StopFlicker");
   }
 
   @Override
@@ -123,12 +117,12 @@ public class Flicker extends SubsystemBase {
     builder.addBooleanProperty("IsAtSetpoint", this::isAtSetpoint, null);
   }
 
-   /** Heights and angles to score on the reef. */
+  /** Heights and angles to score on the reef. */
   public enum ReefScoringConfiguration {
     STOW(FlickerConfig.STOW_HEIGHT, FlickerConfig.STOW_ANGLE),
     L2(FlickerConfig.L2_HEIGHT, FlickerConfig.L2_ANGLE),
     L3(FlickerConfig.L3_HEIGHT, FlickerConfig.L3_ANGLE);
-  
+
     /** Inches */
     private final double elevatorPosition;
     /** Degrees */
@@ -137,10 +131,6 @@ public class Flicker extends SubsystemBase {
     private ReefScoringConfiguration(double elevatorPosition, double anglerPosition) {
       this.elevatorPosition = elevatorPosition;
       this.flickerPosition = anglerPosition;
-
-
-
     }
-
   }
 }

--- a/src/main/java/frc/robot/subsystems/algae/collector/AlgaeCollector.java
+++ b/src/main/java/frc/robot/subsystems/algae/collector/AlgaeCollector.java
@@ -8,17 +8,19 @@ public class AlgaeCollector extends SubsystemBase {
   private final Intake intake = new Intake();
   private final Wrist wrist = new Wrist();
 
-  public Command position(double pos) {
-    return startEnd(
-        () -> wrist.setAngleCommand(pos),
-        wrist::stop
-      )
-      .withName("PositionWrist");
+  public Command setPosition(double pos) {
+    var cmd = Commands.parallel(
+      wrist.setAngleCommand(pos)
+    );
+    cmd.addRequirements(this);
+    return cmd.withName("PositionWrist");
   }
 
   public Command intakeAlgae() {
-    return startEnd(intake::start, intake::stop)
-      .until(intake::hasAlgae)
+    var cmd = startEnd(intake::start, intake::stop)
+      .until(intake::hasAlgae);
+    cmd.addRequirements(intake);
+    return cmd
       .withTimeout(3)
       .withName("IntakeAlgae");
   }
@@ -32,10 +34,11 @@ public class AlgaeCollector extends SubsystemBase {
   }
 
   public Command stopCommand() {
-    return Commands.parallel(
+    var cmd = Commands.parallel(
       intake.stopCommand(),
       wrist.stopCommand()
-    ).withName("StopAlgaeCollector");
+    );
+    cmd.addRequirements(this);
+    return cmd.withName("StopAlgaeCollector");
   }
-
 }

--- a/src/main/java/frc/robot/subsystems/coraller/Angler.java
+++ b/src/main/java/frc/robot/subsystems/coraller/Angler.java
@@ -51,14 +51,13 @@ class Angler extends SubsystemBase {
   }
 
   public Command setAngleCommand(double angleDegrees) {
-    return this.run(() -> setSetpointAngle(angleDegrees))
-      .until(this::isAtSetpoint)
-      .withName("SetAnglerSetpoint");
+    var cmd = this.run(() -> setSetpointAngle(angleDegrees)).until(this::isAtSetpoint);
+    return cmd.withName("SetAnglerSetpoint");
   }
 
   public Command stopCommand() {
-    return runOnce(this::stop)
-      .withName("StopAngler");
+    var cmd = runOnce(this::stop);
+    return cmd.withName("StopAngler");
   }
 
   /**

--- a/src/main/java/frc/robot/subsystems/coraller/Coraller.java
+++ b/src/main/java/frc/robot/subsystems/coraller/Coraller.java
@@ -26,10 +26,12 @@ public class Coraller extends SubsystemBase {
   }
 
   public Command prepareToScoreReef(ReefScoringConfiguration cfg) {
-    return Commands.parallel(
+    var cmd = Commands.parallel(
       elevator.setHeightCommand(cfg.elevatorPosition),
       angler.setAngleCommand(cfg.anglerPosition)
-    ).withName("PrepareToScoreReef");
+    );
+    cmd.addRequirements(this);
+    return cmd.withName("PrepareToScoreReef");
   }
 
   public Command intakeCoral() {
@@ -50,11 +52,13 @@ public class Coraller extends SubsystemBase {
   }
 
   public Command stopCommand() {
-    return Commands.parallel(
+    var cmd = Commands.parallel(
       elevator.stopCommand(),
       angler.stopCommand(),
       intake.stopCommand()
-    ).withName("StopCoraller");
+    );
+    cmd.addRequirements(this);
+    return cmd.withName("StopCoraller");
   }
 
   public void stop() {

--- a/src/main/java/frc/robot/subsystems/coraller/Intake.java
+++ b/src/main/java/frc/robot/subsystems/coraller/Intake.java
@@ -43,8 +43,8 @@ class Intake extends SubsystemBase {
   }
 
   public Command stopCommand() {
-    return runOnce(this::stop)
-      .withName("StopIntake");
+    var cmd = runOnce(this::stop);
+    return cmd.withName("StopIntake");
   }
 
   public void start() {
@@ -55,8 +55,8 @@ class Intake extends SubsystemBase {
   }
 
   public Command intakeCommand() {
-    return runOnce(this::start)
-      .withName("StartIntake");
+    var cmd = runOnce(this::start);
+    return cmd.withName("StartIntake");
   }
 
   public void reverse() {
@@ -67,8 +67,8 @@ class Intake extends SubsystemBase {
   }
 
   public Command reverseCommand() {
-    return runOnce(this::reverse)
-      .withName("ReverseIntake");
+    var cmd = runOnce(this::reverse);
+    return cmd.withName("ReverseIntake");
   }
 
   public boolean hasCoral() {

--- a/src/main/java/frc/robot/subsystems/drive/SwerveDrive.java
+++ b/src/main/java/frc/robot/subsystems/drive/SwerveDrive.java
@@ -311,12 +311,13 @@ public class SwerveDrive extends SubsystemBase {
    * @return the command to reset the robot heading
    */
   public Command resetHeading() {
-    return runOnce(() -> {
+    var cmd = runOnce(() -> {
       var currentPose = getPose();
       var currentAlliance = DriverStation.getAlliance().isPresent() ? DriverStation.getAlliance().get() : Alliance.Blue;
       var awayAngle = currentAlliance == Alliance.Red ? 180 : 0;
       resetPose(new Pose2d(currentPose.getX(), currentPose.getY(), Rotation2d.fromDegrees(awayAngle)));
-    }).withName("ResetRobotHeading");
+    });
+    return cmd.withName("ResetRobotHeading");
   }
 
   /**
@@ -433,7 +434,7 @@ public class SwerveDrive extends SubsystemBase {
    */
   public Command driveWithXboxController(CommandXboxController hid, BooleanSupplier fieldRelative,
       double joystickDeadband, double joystickSensitivity) {
-    return runEnd(() -> {
+    var cmd = runEnd(() -> {
       // Get the x speed. We are inverting this because Xbox controllers return
       // negative values when we push forward.
       var xSpeed = 0.0;
@@ -467,7 +468,8 @@ public class SwerveDrive extends SubsystemBase {
       var alliance = DriverStation.getAlliance().isPresent() ? DriverStation.getAlliance().get() : Alliance.Blue;
       var sign = fieldRelative.getAsBoolean() && alliance == Alliance.Red ? -1 : 1;
       drive(sign * xSpeed, sign * ySpeed, rotationSpeed, fieldRelative.getAsBoolean());
-    }, this::stop).withName("DriveWithXboxController");
+    }, this::stop);
+    return cmd.withName("DriveWithXboxController");
   }
 
   /**
@@ -540,7 +542,8 @@ public class SwerveDrive extends SubsystemBase {
    * @return a command to stop all modules
    */
   public Command stopCommand() {
-    return runOnce(this::stop).withName("StopSwerve");
+    var cmd = runOnce(this::stop);
+    return cmd.withName("StopSwerve");
   }
 
   /**


### PR DESCRIPTION
* Require "superstructure" subsystem for some commands
* Use `withName` at the very end to ensure we do not use the `WrapperCommand` until the very end of building the command